### PR TITLE
Fix for inititiation problem in Qlik Sense November 2018

### DIFF
--- a/3.Include/4.Sub/5.DoDir.qvs
+++ b/3.Include/4.Sub/5.DoDir.qvs
@@ -1,13 +1,13 @@
-/* ___________________________________________________________________________
-  |   Deployment Framework DoDir sub function 5.DoDir.qvs 
-  |
-  | Returns a Table containing files and path in selected file system (vL.QDF.DoDirRoot)
-  | First include the DoDir Function $(Include=$(vG.SubPath)\5.DoDir.qvs);
-  | Use the function DoDir to execute. examples:
-  | call DoDir ('$(vG.RootPath)'); //Simple Example
-  | call DoDir ('$(vG.RootPath)\*.qvd'); //Simple Example
-  | call DoDir ('$(vG.BasePath),Table Name)'); //Change Table name 
-*/
+// ___________________________________________________________________________
+//  |   Deployment Framework DoDir sub function 5.DoDir.qvs 
+//  |
+//  | Returns a Table containing files and path in selected file system (vL.QDF.DoDirRoot)
+//  | First include the DoDir Function $(Include=$(vG.SubPath)\5.DoDir.qvs);
+//  | Use the function DoDir to execute. examples:
+//  | call DoDir ('$(vG.RootPath)'); //Simple Example
+//  | call DoDir ('$(vG.RootPath)\*.qvd'); //Simple Example
+//  | call DoDir ('$(vG.BasePath),Table Name)'); //Change Table name 
+//
 sub DoDir (vL.QDF.DoDirRoot,vL.QDF.DoDirTableName,vL.QDF.FoldersOnly,vL.QDF.SingleFolder,vL.QDF.QualifyFelds,vL.QDF.Template_Exeptions)
 
 let vL.QDF.DoDirRoot=trim('$(vL.QDF.DoDirRoot)'); // Trim vL.QDF.DoDirRoot

--- a/3.Include/4.Sub/99.LoadAll.qvs
+++ b/3.Include/4.Sub/99.LoadAll.qvs
@@ -1,8 +1,8 @@
-/* 
-### This script loads all sub functions in one single batch
-### It's run automatically by 1.Init.qvs QDF during initiation
-### $(Must_Include=$(vG.SubPath)\99.LoadAll.qvs);
-*/
+// 
+//### This script loads all sub functions in one single batch
+//### It's run automatically by 1.Init.qvs QDF during initiation
+//### $(Must_Include=$(vG.SubPath)\99.LoadAll.qvs);
+//
 $(Include=$(vG.$(vL.QDF.LinkShared_Folders)SubPath)\1.FileExist.qvs);
 $(Include=$(vG.$(vL.QDF.LinkShared_Folders)SubPath)\2.LoadVariableCSV.qvs);
 $(Include=$(vG.$(vL.QDF.LinkShared_Folders)SubPath)\3.LoadContainerMap.qvs);


### PR DESCRIPTION
Changed initiating comment style from block to line in a couple of SUB qvs-files. 
Qlik Sense November 2018 is handdling block in qvs-files poorly.