### PR TITLE
Make sure to load correct index folder

### DIFF
--- a/3.Include/4.Sub/12.Index.qvs
+++ b/3.Include/4.Sub/12.Index.qvs
@@ -202,9 +202,9 @@ endif
 
 
 If not '$(vL.QDF.IndexQVD)' = '' and substringcount( '$(vL.QDF.IndexQVD)' , '*') =0 then 
-  let vL.QDF.IndexQVD ='*'&'$(vL.QDF.IndexQVD)'&'*.index';
+  let vL.QDF.IndexQVD ='*'&'$(vL.QDF.IndexFolderName)$(vL.QDF.IndexQVD)'&'*.index';
 else
-  let vL.QDF.IndexQVD ='*.index';
+  let vL.QDF.IndexQVD ='*$(vL.QDF.IndexFolderName).index';
 endif
 
 //-----------------Load in Index folders ---------------------------


### PR DESCRIPTION
As from the script of IndexAdd, there isn't a real folder structure, the folder deliminator is replaced by "_", 
so currently the IndexLoad will be loaded without the consideration of index folder.
Changes are to make sure only the index under correct index folder is loaded.